### PR TITLE
Sync Feishu coordination copy pack

### DIFF
--- a/marketing/application/project-description.md
+++ b/marketing/application/project-description.md
@@ -5,9 +5,10 @@
 `openclaw-oss-starter` is a public-safe OpenClaw skill collection for local AI
 coordination workflows. The repository maintains reusable templates for
 structured task intake, confirmation-based execution, reminder orchestration,
-completion tracking, and Mac multi-instance deployment. It is designed to keep
-private runtime state local while publishing reusable workflow patterns,
-documentation, and skills that others can adapt safely.
+completion tracking, Mac multi-instance deployment, and public-safe Feishu
+coordination templates. It is designed to keep private runtime state local
+while publishing reusable workflow patterns, documentation, and skills that
+others can adapt safely.
 
 ## Slightly expanded version
 
@@ -16,9 +17,10 @@ coordination with OpenClaw-style skills and reusable automation patterns. The
 project focuses on turning practical local workflows into reusable public-safe
 templates without exposing private runtime state, personal identities, or
 sensitive operating details. Current areas include daily task check-ins, family
-homework coordination, practice-session reminders, and Mac multi-instance
-deployment. The repository is also used to publish selected skills to ClawHub
-and to document repeatable patterns for adaptation by other operators.
+homework coordination, practice-session reminders, Mac multi-instance
+deployment, and public-safe Feishu coordination/message templates. The repository is
+also used to publish selected skills to ClawHub and to document repeatable
+patterns for adaptation by other operators.
 
 ## Why this repository qualifies
 
@@ -41,4 +43,5 @@ AI operators while keeping the public version privacy-safe and easy to adapt.
 
 Public-safe OpenClaw skill collection for local AI coordination workflows,
 including reusable templates for task check-ins, homework coordination,
-practice-session reminders, and Mac multi-instance deployment.
+practice-session reminders, Mac multi-instance deployment, and public-safe
+Feishu coordination templates.

--- a/marketing/feishu/2026-03-27-launch.md
+++ b/marketing/feishu/2026-03-27-launch.md
@@ -11,6 +11,7 @@ with reusable templates for:
 - homework coordination
 - practice-session follow-up
 - generic Mac multi-instance deployment
+- public-safe Feishu coordination templates
 
 The repo now includes multiple public-safe skills, ClawHub-published entries,
 and a cleaner Mac deployment template for multi-instance setups.
@@ -29,7 +30,7 @@ now a practical starting point.
 
 Updated `openclaw-oss-starter` into a more complete public-safe OpenClaw skill
 collection for local AI workflows, including daily task, homework, practice,
-and Mac multi-instance deployment templates.
+Mac multi-instance deployment, and Feishu coordination templates.
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter
@@ -51,6 +52,7 @@ The direction is simple:
 - keep runtime state private
 - make reusable workflow templates public
 - publish practical skills to ClawHub
+- add public-safe Feishu coordination templates where abstraction is clean
 
 This makes the project useful both as a reference repo and as a starter pack
 for OpenClaw-style local coordination setups.
@@ -66,8 +68,8 @@ ClawHub:
 
 Built `openclaw-oss-starter` into a public-safe OpenClaw skill collection for
 local AI workflows. The current set includes task, homework, practice, and Mac
-multi-instance deployment templates, with selected skills already on ClawHub.
+multi-instance deployment templates plus Feishu coordination templates, with
+selected skills already on ClawHub.
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter
-

--- a/marketing/feishu/2026-03-27-media-final.md
+++ b/marketing/feishu/2026-03-27-media-final.md
@@ -4,7 +4,7 @@
 
 Built `openclaw-oss-starter` into a public-safe OpenClaw skill collection for
 local AI workflows, covering daily tasks, homework, practice-session follow-up,
-and Mac multi-instance deployment.
+Mac multi-instance deployment, and reusable Feishu coordination templates.
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter
@@ -26,6 +26,7 @@ The direction is simple:
 - keep runtime state private
 - make reusable workflow templates public
 - publish practical skills to ClawHub
+- add public-safe Feishu coordination templates where they can stay generic
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter
@@ -34,7 +35,7 @@ https://github.com/ztl970/openclaw-oss-starter
 
 Built `openclaw-oss-starter` into a public-safe OpenClaw skill collection for
 local AI workflows, including task, homework, practice, and Mac multi-instance
-deployment templates.
+deployment templates plus Feishu coordination templates.
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter

--- a/marketing/feishu/knowledge-base/01-project-overview.md
+++ b/marketing/feishu/knowledge-base/01-project-overview.md
@@ -17,6 +17,7 @@
 - 家庭作业协同
 - 专项练习打卡
 - Mac 多实例部署
+- public-safe 飞书协同模板
 
 ## 当前代表性 skills
 
@@ -25,11 +26,17 @@
 - `practice-session-checkin`
 - `mac-multi-instance-deployment`
 
+## 当前公开模板补充
+
+- `36-public-safe-ops-message-templates.md`
+- public-safe 飞书协同与结构化消息模板
+
 ## 对外发布状态
 
 - GitHub 仓库已公开
 - 多个 skill 已发布到 ClawHub
 - 当前已经整理出面向 Feishu、小红书、X 和长文渠道的营销素材
+- 已补充一组适合继续沉淀到知识库的 public-safe 飞书协同模板
 
 ## 项目地址
 

--- a/marketing/feishu/knowledge-base/02-publishing-copy.md
+++ b/marketing/feishu/knowledge-base/02-publishing-copy.md
@@ -4,7 +4,7 @@
 
 Built `openclaw-oss-starter` into a public-safe OpenClaw skill collection for
 local AI workflows, covering daily tasks, homework, practice-session follow-up,
-and Mac multi-instance deployment.
+Mac multi-instance deployment, and reusable Feishu coordination templates.
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter
@@ -26,6 +26,7 @@ The direction is simple:
 - keep runtime state private
 - make reusable workflow templates public
 - publish practical skills to ClawHub
+- add public-safe Feishu coordination templates when they can be abstracted safely
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter
@@ -38,7 +39,7 @@ https://github.com/ztl970/openclaw-oss-starter
 
 ### Subtitle
 
-覆盖任务打卡、家庭作业、专项练习、Mac 多实例部署
+覆盖任务打卡、家庭作业、专项练习、Mac 多实例部署与飞书协同模板
 
 ### Short body
 

--- a/marketing/feishu/knowledge-base/11-short-intro-pack.md
+++ b/marketing/feishu/knowledge-base/11-short-intro-pack.md
@@ -14,17 +14,17 @@ A public-safe OpenClaw skill collection for local AI coordination workflows.
 
 ## 英文短介绍
 
-`openclaw-oss-starter` is a public-safe OpenClaw skill collection for local AI coordination workflows, including reusable templates for tasks, homework coordination, practice-session follow-up, and Mac multi-instance deployment.
+`openclaw-oss-starter` is a public-safe OpenClaw skill collection for local AI coordination workflows, including reusable templates for tasks, homework coordination, practice-session follow-up, Mac multi-instance deployment, and Feishu coordination.
 
 ## 适合复制到不同地方的短版
 
 ### GitHub / 简介
 
-Public-safe OpenClaw skills for local AI coordination and deployment.
+Public-safe OpenClaw skills for local AI coordination, deployment, and Feishu workflow templates.
 
 ### Feishu / 群介绍
 
-这是一个已经公开整理并持续维护的 OpenClaw 项目模板库，适合本地 AI 工作流、任务协同和多实例部署参考。
+这是一个已经公开整理并持续维护的 OpenClaw 项目模板库，适合本地 AI 工作流、任务协同、多实例部署和飞书协同模板参考。
 
 ### 小红书 / 中文短介绍
 
@@ -32,4 +32,4 @@ Public-safe OpenClaw skills for local AI coordination and deployment.
 
 ### 申请摘要
 
-Public-safe OpenClaw skill collection for local AI coordination workflows, including reusable templates for task check-ins, homework coordination, practice-session reminders, and Mac multi-instance deployment.
+Public-safe OpenClaw skill collection for local AI coordination workflows, including reusable templates for task check-ins, homework coordination, practice-session reminders, Mac multi-instance deployment, and Feishu coordination.

--- a/marketing/feishu/knowledge-base/run_media_sync.sh
+++ b/marketing/feishu/knowledge-base/run_media_sync.sh
@@ -30,6 +30,7 @@ ${PARENT_URL}
 - 09_后续待办与选题方向 <- ${ROOT_DIR}/09-next-steps-and-content-ideas.md
 - 10_链接总表 <- ${ROOT_DIR}/10-link-index.md
 - 11_对外简介速用版 <- ${ROOT_DIR}/11-short-intro-pack.md
+- 36_Public-safe运营消息模板 <- ${ROOT_DIR}/36-public-safe-ops-message-templates.md
 EOF
 )
 


### PR DESCRIPTION
## Summary
- sync application, launch, and media copy with the new Feishu coordination template positioning
- update Feishu knowledge-base overview and short intro pages to include the public-safe coordination templates
- add the public-safe ops message template page to the media sync script
- keep 30/31/32 internal ops rule drafts out of this PR

## Validation
- git diff --check -- marketing/application/project-description.md marketing/feishu/2026-03-27-launch.md marketing/feishu/2026-03-27-media-final.md marketing/feishu/knowledge-base/01-project-overview.md marketing/feishu/knowledge-base/02-publishing-copy.md marketing/feishu/knowledge-base/11-short-intro-pack.md marketing/feishu/knowledge-base/run_media_sync.sh