### PR TITLE
Add Vertex skill release kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows a lightweight keep-a-changelog style.
 
 ## [Unreleased]
 
+- Expanded the Vertex setup skill with examples, customization guidance, and a
+  first skill release note for ClawHub evaluation
 - Added a GitHub-first public-safe skill for credit-safe Google Vertex AI setup
 - Added repository and knowledge-base references for the new Vertex setup skill
 - Quota-aware switching now uses public-safe config variables for threshold,

--- a/skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md
+++ b/skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Added the first public-safe Vertex AI setup skill structure
 - Added a compact first-setup checklist
 - Added a minimal placeholder-only reference config
+- Added a compact example pack for setup and verification
+- Added a customization guide and first skill release note

--- a/skills/openclaw-vertex-credit-safe-setup/CUSTOMIZATION.md
+++ b/skills/openclaw-vertex-credit-safe-setup/CUSTOMIZATION.md
@@ -1,0 +1,28 @@
+# Customization Guide
+
+This skill can be adapted for different Vertex AI onboarding styles.
+
+## Customizable fields
+
+- target project wording
+- service-account JSON path conventions
+- minimal model set
+- verification prompt wording
+- billing check wording
+
+## Suggested adaptation patterns
+
+- one-project starter setup
+- trial-credit verification setup
+- team onboarding checklist
+- private workstation setup handoff
+
+## Public-safe reminder
+
+Before publishing a customized variant, remove:
+
+- real project IDs
+- real JSON credential paths
+- service-account JSON contents
+- API keys or app secrets
+- private billing account details

--- a/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
+++ b/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
@@ -10,6 +10,9 @@ verification.
 - a human-readable `README.md`
 - a smallest-possible reference config with placeholders only
 - a checklist that emphasizes billing verification before wider rollout
+- a compact example pack
+- a customization guide
+- a first skill release note
 
 ## Positioning
 
@@ -23,7 +26,7 @@ Use this skill when you want a reusable public template for:
 
 - GitHub: yes
 - Feishu knowledge-base: yes, as a repository-facing summary update
-- ClawHub: not yet
+- ClawHub: ready for evaluation
 
-ClawHub can wait until the skill has broader examples or a more stable public
-release cadence.
+This skill now has the minimum packaging needed for a ClawHub release review,
+but publishing can still wait until you want a public registry entry.

--- a/skills/openclaw-vertex-credit-safe-setup/README.md
+++ b/skills/openclaw-vertex-credit-safe-setup/README.md
@@ -46,13 +46,21 @@ skills/
   openclaw-vertex-credit-safe-setup/
     SKILL.md
     README.md
+    CUSTOMIZATION.md
     PUBLISHING.md
     CHANGELOG.md
     agents/
       openai.yaml
+    examples/
+      README.md
+      quickstart.md
+      local-env-example.md
+      verification-example.md
     references/
       minimal-vertex-reference-config.md
       vertex-first-setup-checklist.md
+    releases/
+      1.0.0.md
 ```
 
 ## Safety boundaries
@@ -80,3 +88,9 @@ Keep this skill public-safe:
 3. merge the minimal model block into your local OpenClaw config
 4. run one tiny verification request
 5. check the `Vertex AI` billing line item before broader rollout
+
+## More links
+
+- [examples/README.md](./examples/README.md)
+- [CUSTOMIZATION.md](./CUSTOMIZATION.md)
+- [releases/1.0.0.md](./releases/1.0.0.md)

--- a/skills/openclaw-vertex-credit-safe-setup/examples/README.md
+++ b/skills/openclaw-vertex-credit-safe-setup/examples/README.md
@@ -1,0 +1,15 @@
+# Examples
+
+Short index for the public-safe Vertex AI setup walkthrough.
+
+## Files
+
+- [quickstart.md](./quickstart.md)
+- [local-env-example.md](./local-env-example.md)
+- [verification-example.md](./verification-example.md)
+
+## Read order
+
+1. `quickstart.md`
+2. `local-env-example.md`
+3. `verification-example.md`

--- a/skills/openclaw-vertex-credit-safe-setup/examples/local-env-example.md
+++ b/skills/openclaw-vertex-credit-safe-setup/examples/local-env-example.md
@@ -1,0 +1,15 @@
+# Local Env Example
+
+Use a private shell profile or a local-only env file.
+
+```bash
+export GOOGLE_CLOUD_PROJECT="<gcp-project-id>"
+export GOOGLE_APPLICATION_CREDENTIALS="$HOME/openclaw/private/google/<service-account>.json"
+```
+
+## Notes
+
+- replace both placeholders locally
+- do not commit the JSON file
+- do not paste JSON contents into repo files
+- keep the path generic in any shared documentation

--- a/skills/openclaw-vertex-credit-safe-setup/examples/quickstart.md
+++ b/skills/openclaw-vertex-credit-safe-setup/examples/quickstart.md
@@ -1,0 +1,15 @@
+# Quickstart
+
+Use this short sequence for a first local pass.
+
+1. decide the target Google Cloud project
+2. confirm billing or credits are attached to that project
+3. place the service-account JSON in a private local folder
+4. set `GOOGLE_CLOUD_PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS`
+5. merge the minimal `google-vertex/...` model block into the local OpenClaw config
+6. run one tiny verification request
+7. check that Google Cloud Billing shows `Vertex AI`
+
+## Public-safe rule
+
+Keep the JSON file outside the repository and keep all examples on placeholders only.

--- a/skills/openclaw-vertex-credit-safe-setup/examples/verification-example.md
+++ b/skills/openclaw-vertex-credit-safe-setup/examples/verification-example.md
@@ -1,0 +1,21 @@
+# Verification Example
+
+Example of the smallest acceptable handoff after one tiny request.
+
+## Example summary
+
+- provider: `google-vertex`
+- model: `google-vertex/gemini-2.5-flash`
+- target project: `<gcp-project-id>`
+- auth method: `service-account JSON`
+- result: `request succeeded`
+
+## Required next check
+
+Do not stop at request success alone.
+
+Tell the user to verify:
+
+- the billing line item is `Vertex AI`
+- the intended project was charged
+- credits or trial balance were applied as expected

--- a/skills/openclaw-vertex-credit-safe-setup/releases/1.0.0.md
+++ b/skills/openclaw-vertex-credit-safe-setup/releases/1.0.0.md
@@ -1,0 +1,27 @@
+# v1.0.0
+
+## Highlights
+
+- added a public-safe starter skill for first-time Google Vertex AI setup
+- added a minimal placeholder-only reference config
+- added compact examples for local env setup and billing-aware verification
+
+## Changes
+
+- `skills/openclaw-vertex-credit-safe-setup/SKILL.md`
+- `skills/openclaw-vertex-credit-safe-setup/README.md`
+- `skills/openclaw-vertex-credit-safe-setup/CUSTOMIZATION.md`
+- `skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md`
+- `skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md`
+- `skills/openclaw-vertex-credit-safe-setup/agents/openai.yaml`
+- `skills/openclaw-vertex-credit-safe-setup/references/minimal-vertex-reference-config.md`
+- `skills/openclaw-vertex-credit-safe-setup/references/vertex-first-setup-checklist.md`
+- `skills/openclaw-vertex-credit-safe-setup/examples/README.md`
+- `skills/openclaw-vertex-credit-safe-setup/examples/quickstart.md`
+- `skills/openclaw-vertex-credit-safe-setup/examples/local-env-example.md`
+- `skills/openclaw-vertex-credit-safe-setup/examples/verification-example.md`
+
+## Notes
+
+- Keep all project IDs, JSON credential files, and billing details local-only.
+- This version is structured for GitHub and is ready for ClawHub evaluation.

--- a/validate_repo.sh
+++ b/validate_repo.sh
@@ -24,7 +24,10 @@ required=(
   "skills/family-homework-pomodoro/agents/openai.yaml"
   "skills/openclaw-vertex-credit-safe-setup/SKILL.md"
   "skills/openclaw-vertex-credit-safe-setup/README.md"
+  "skills/openclaw-vertex-credit-safe-setup/CUSTOMIZATION.md"
   "skills/openclaw-vertex-credit-safe-setup/agents/openai.yaml"
+  "skills/openclaw-vertex-credit-safe-setup/examples/README.md"
+  "skills/openclaw-vertex-credit-safe-setup/releases/1.0.0.md"
 )
 
 missing=0


### PR DESCRIPTION
## Summary
- add the minimum release-kit structure for the Vertex setup skill
- include examples, a customization guide, and a skill-level release note
- extend repo validation to cover the new public skill entrypoints

## Sync scope
- GitHub: yes
- Feishu knowledge-base: no additional page changes needed for this pass
- ClawHub: evaluate after merge

## Notes
- this keeps the skill public-safe and placeholder-only
- the top-level README still correctly shows the skill as not yet published on ClawHub