### PR TITLE
Sync Vertex skill ClawHub status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows a lightweight keep-a-changelog style.
 
 ## [Unreleased]
 
+- Published `openclaw-vertex-credit-safe-setup@1.0.0` to ClawHub and synced the
+  public repo status
 - Expanded the Vertex setup skill with examples, customization guidance, and a
   first skill release note for ClawHub evaluation
 - Added a GitHub-first public-safe skill for credit-safe Google Vertex AI setup

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Current focus areas include:
 | `daily-task-checkin` | Lightweight task intake, reminders, completion confirmation, and follow-up coordination | `1.0.2` | [`skills/daily-task-checkin/`](./skills/daily-task-checkin/) |
 | `practice-session-checkin` | Structured practice intake, start confirmation, reminder flow, and follow-up tracking | `1.0.1` | [`skills/practice-session-checkin/`](./skills/practice-session-checkin/) |
 | `mac-multi-instance-deployment` | Generic Mac workspace setup, boundary docs, quickstart examples, and deployment validation | `1.0.4` | [`skills/mac-multi-instance-deployment/`](./skills/mac-multi-instance-deployment/) |
-| `openclaw-vertex-credit-safe-setup` | Google Vertex AI setup with service-account JSON, tiny verification, and billing checks | `not yet` | [`skills/openclaw-vertex-credit-safe-setup/`](./skills/openclaw-vertex-credit-safe-setup/) |
+| `openclaw-vertex-credit-safe-setup` | Google Vertex AI setup with service-account JSON, tiny verification, and billing checks | `1.0.0` | [`skills/openclaw-vertex-credit-safe-setup/`](./skills/openclaw-vertex-credit-safe-setup/) |
 
 ### Featured Entry Point
 
@@ -205,3 +205,4 @@ Published on ClawHub:
 - daily-task-checkin
 - practice-session-checkin
 - mac-multi-instance-deployment
+- openclaw-vertex-credit-safe-setup

--- a/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
+++ b/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
@@ -26,7 +26,7 @@ Use this skill when you want a reusable public template for:
 
 - GitHub: yes
 - Feishu knowledge-base: yes, as a repository-facing summary update
-- ClawHub: ready for evaluation
+- ClawHub: published as `openclaw-vertex-credit-safe-setup@1.0.0`
 
-This skill now has the minimum packaging needed for a ClawHub release review,
-but publishing can still wait until you want a public registry entry.
+This skill now has the minimum packaging needed for a stable public registry
+entry and has been published on ClawHub.

--- a/skills/openclaw-vertex-credit-safe-setup/README.md
+++ b/skills/openclaw-vertex-credit-safe-setup/README.md
@@ -4,7 +4,7 @@ Public-safe OpenClaw skill for connecting a fresh local setup to Google Vertex
 AI with service-account JSON auth, one tiny verification request, and explicit
 billing checks.
 
-This skill is GitHub-first for now. It is not yet published on ClawHub.
+Published on ClawHub as `openclaw-vertex-credit-safe-setup@1.0.0`.
 
 ## What it does
 
@@ -78,7 +78,7 @@ Keep this skill public-safe:
 - fresh OpenClaw setup guidance
 - Google Vertex AI trial or credit-safe onboarding
 - public-safe deployment examples
-- GitHub-first setup documentation before broader registry release
+- GitHub and ClawHub-ready setup documentation for broader registry use
 
 ## Suggested quickstart
 


### PR DESCRIPTION
## Summary
- sync the repo homepage and skill docs after publishing the Vertex setup skill to ClawHub
- update the included-skills table and published-skill list
- record the ClawHub publication in the repo changelog

## Evidence
- published slug: openclaw-vertex-credit-safe-setup
- latest version: 1.0.0
- owner: ztl970

## Notes
- this PR only updates public-facing status text after the successful ClawHub publish