### PR TITLE
Sync Feishu knowledge base for Vertex release

### DIFF
--- a/marketing/feishu/knowledge-base/01-project-overview.md
+++ b/marketing/feishu/knowledge-base/01-project-overview.md
@@ -37,6 +37,7 @@
 
 - GitHub 仓库已公开
 - 多个 skill 已发布到 ClawHub
+- `openclaw-vertex-credit-safe-setup@1.0.0` 已进入 ClawHub
 - 当前已经整理出面向 Feishu、小红书、X 和长文渠道的营销素材
 - 已补充一组适合继续沉淀到知识库的 public-safe 飞书协同模板
 

--- a/marketing/feishu/knowledge-base/02-publishing-copy.md
+++ b/marketing/feishu/knowledge-base/02-publishing-copy.md
@@ -4,7 +4,8 @@
 
 Built `openclaw-oss-starter` into a public-safe OpenClaw skill collection for
 local AI workflows, covering daily tasks, homework, practice-session follow-up,
-Mac multi-instance deployment, and reusable Feishu coordination templates.
+Mac multi-instance deployment, Google Vertex AI setup, and reusable Feishu
+coordination templates.
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter
@@ -20,6 +21,7 @@ Current public skills include:
 - `family-homework-pomodoro`
 - `practice-session-checkin`
 - `mac-multi-instance-deployment`
+- `openclaw-vertex-credit-safe-setup`
 
 The direction is simple:
 
@@ -39,7 +41,7 @@ https://github.com/ztl970/openclaw-oss-starter
 
 ### Subtitle
 
-覆盖任务打卡、家庭作业、专项练习、Mac 多实例部署与飞书协同模板
+覆盖任务打卡、家庭作业、专项练习、Mac 多实例部署、Vertex AI 安全接入与飞书协同模板
 
 ### Short body
 

--- a/marketing/feishu/knowledge-base/07-project-milestones.md
+++ b/marketing/feishu/knowledge-base/07-project-milestones.md
@@ -20,6 +20,7 @@
 ### 社区发布
 
 - 多个 skill 已发布到 ClawHub
+- `openclaw-vertex-credit-safe-setup@1.0.0` 已补入公开分发链
 - 项目已经具备对外展示和社区分发能力
 
 ### 知识库沉淀


### PR DESCRIPTION
## Summary
- sync the Feishu knowledge-base overview and milestone pages after the Vertex skill ClawHub release
- update the publishing-copy page so the public skill list includes the Vertex setup skill
- keep this pass limited to knowledge-base-facing text only

## Sync scope
- GitHub: yes, for source files
- Feishu knowledge-base: yes
- ClawHub: already published, no new change here

## Notes
- this PR does not touch business logic or local-only files