### PR TITLE
Clarify Vertex skill credit-safe cover intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ practical setup layer, not just a documentation layer.
 [`openclaw-vertex-credit-safe-setup`](./skills/openclaw-vertex-credit-safe-setup/README.md)
 is the cloud-setup companion template. It keeps first-time Vertex AI setup on a
 public-safe path with local-only credentials, one small verification request,
-and explicit billing checks.
+and explicit billing checks so users with Google Cloud credits can configure
+OpenClaw to use Gemini through Vertex AI more safely.
 
 ## Project Positioning
 

--- a/marketing/feishu/knowledge-base/02-publishing-copy.md
+++ b/marketing/feishu/knowledge-base/02-publishing-copy.md
@@ -7,6 +7,10 @@ local AI workflows, covering daily tasks, homework, practice-session follow-up,
 Mac multi-instance deployment, Google Vertex AI setup, and reusable Feishu
 coordination templates.
 
+The Vertex setup skill is there for a concrete reason: many users may already
+have Google Cloud credits, but still need a clear way to configure OpenClaw so
+Gemini usage lands on the Vertex AI billing path instead of a wrong setup path.
+
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter
 
@@ -29,6 +33,7 @@ The direction is simple:
 - make reusable workflow templates public
 - publish practical skills to ClawHub
 - add public-safe Feishu coordination templates when they can be abstracted safely
+- help users turn available Google Cloud credits into a correct OpenClaw setup path
 
 GitHub:
 https://github.com/ztl970/openclaw-oss-starter

--- a/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
+++ b/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
@@ -4,6 +4,10 @@
 skill for connecting OpenClaw to Google Vertex AI with minimal-cost
 verification.
 
+It exists for a practical reason: users may already have Google Cloud credits,
+but still need a reliable way to point OpenClaw at Vertex AI so Gemini usage
+lands on the intended billing path.
+
 ## What this addition provides
 
 - a setup-focused `SKILL.md`
@@ -21,6 +25,7 @@ Use this skill when you want a reusable public template for:
 - first-time Vertex AI setup
 - credit-safe or trial-safe Google Cloud onboarding
 - keeping OpenClaw model routing on `google-vertex/...`
+- turning Google Cloud credits into a correct OpenClaw + Gemini setup path
 
 ## Current release scope
 

--- a/skills/openclaw-vertex-credit-safe-setup/README.md
+++ b/skills/openclaw-vertex-credit-safe-setup/README.md
@@ -6,6 +6,37 @@ billing checks.
 
 Published on ClawHub as `openclaw-vertex-credit-safe-setup@1.0.0`.
 
+## Why this skill exists
+
+Many users can access Google Cloud credits, but still miss the practical setup
+step that makes those credits useful inside OpenClaw.
+
+Typical cases include:
+
+- Google for Startups Cloud Program credits
+- Google Cloud / Vertex AI new-customer credits
+- other Google Cloud promotional credit windows tied to the correct billing path
+
+The problem is not only "having credits." The real problem is making sure
+OpenClaw is configured so Gemini usage goes through the `google-vertex/...`
+route instead of an unintended direct Gemini API path.
+
+This skill exists to solve that gap:
+
+- configure OpenClaw to use Vertex AI on purpose
+- keep auth tied to the intended Google Cloud project
+- run one tiny verification request before wider rollout
+- help the user confirm that billing lands under `Vertex AI`
+
+The goal is not to claim "Gemini is always free." The goal is to help users use
+available Google Cloud credits first, avoid wrong-path setup, and minimize
+out-of-pocket cost while credits are still active.
+
+For current program details, always check the official Google pages:
+
+- Google for Startups Cloud Program: https://cloud.google.com/startup
+- Vertex AI: https://cloud.google.com/vertex-ai
+
 ## What it does
 
 Use this skill when you want a safer first pass for Vertex AI setup:
@@ -24,6 +55,12 @@ This skill is meant to reduce a few common setup mistakes:
 - reusing unclear old auth state
 - spreading Google model changes across many agents before a tiny test
 - treating “request succeeded” as proof that billing is correct
+
+In practice, it is also the bridge between:
+
+- Google credits that the user already has
+- OpenClaw model routing
+- Gemini usage inside OpenClaw under the intended Vertex billing path
 
 ## Minimal local inputs
 
@@ -88,6 +125,18 @@ Keep this skill public-safe:
 3. merge the minimal model block into your local OpenClaw config
 4. run one tiny verification request
 5. check the `Vertex AI` billing line item before broader rollout
+
+## What success looks like
+
+The intended end state is simple:
+
+- the user can call Gemini models inside OpenClaw
+- the configured route is `google-vertex/...`
+- billing lands on the intended Google Cloud project
+- eligible Google Cloud credits are used first when available
+
+That is why this skill focuses on billing correctness and not only on whether a
+request succeeds.
 
 ## More links
 


### PR DESCRIPTION
## Summary
- explain why the Vertex skill exists for users with Google Cloud credits
- clarify that the goal is correct OpenClaw-to-Vertex routing, not a blanket free-usage promise
- sync the same positioning to the repo README and Feishu publishing copy

## Validation
- ./validate_repo.sh