### PR TITLE
Polish Vertex skill public entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows a lightweight keep-a-changelog style.
 
 ## [Unreleased]
 
+- Sharpened the Vertex skill entry points and registry-facing metadata so the
+  Google credits, Gemini routing, and billing-path story is easier to follow
 - Published `openclaw-vertex-credit-safe-setup@1.0.0` to ClawHub and synced the
   public repo status
 - Expanded the Vertex setup skill with examples, customization guidance, and a

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Current focus areas include:
 | `daily-task-checkin` | Lightweight task intake, reminders, completion confirmation, and follow-up coordination | `1.0.2` | [`skills/daily-task-checkin/`](./skills/daily-task-checkin/) |
 | `practice-session-checkin` | Structured practice intake, start confirmation, reminder flow, and follow-up tracking | `1.0.1` | [`skills/practice-session-checkin/`](./skills/practice-session-checkin/) |
 | `mac-multi-instance-deployment` | Generic Mac workspace setup, boundary docs, quickstart examples, and deployment validation | `1.0.4` | [`skills/mac-multi-instance-deployment/`](./skills/mac-multi-instance-deployment/) |
-| `openclaw-vertex-credit-safe-setup` | Google Vertex AI setup with service-account JSON, tiny verification, and billing checks | `1.0.0` | [`skills/openclaw-vertex-credit-safe-setup/`](./skills/openclaw-vertex-credit-safe-setup/) |
+| `openclaw-vertex-credit-safe-setup` | Use Google Cloud credits with Gemini through Vertex AI, tiny verification, and billing checks | `1.0.0` | [`skills/openclaw-vertex-credit-safe-setup/`](./skills/openclaw-vertex-credit-safe-setup/) |
 
 ### Featured Entry Point
 
@@ -137,6 +137,12 @@ public-safe path with local-only credentials, one small verification request,
 and explicit billing checks so users with Google Cloud credits can configure
 OpenClaw to use Gemini through Vertex AI more safely, instead of leaving direct
 Gemini API charges behind when routing is wrong.
+
+If that is your specific use case, start there first:
+
+- confirm which Google Cloud project actually owns the credits
+- keep Gemini on the `google-vertex/...` route
+- run one tiny test and verify the `Vertex AI` billing line item before wider use
 
 ## Project Positioning
 

--- a/skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md
+++ b/skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Sharpened the GitHub and ClawHub-facing copy around Google credits, Gemini
+  routing, and billing-path verification
+
 ## 1.0.0
 
 - Added the first public-safe Vertex AI setup skill structure

--- a/skills/openclaw-vertex-credit-safe-setup/README.md
+++ b/skills/openclaw-vertex-credit-safe-setup/README.md
@@ -6,6 +6,16 @@ billing checks.
 
 Published on ClawHub as `openclaw-vertex-credit-safe-setup@1.0.0`.
 
+## Start here if you already have credits
+
+If you want the shortest safe path from Google Cloud credits to Gemini usage
+inside OpenClaw, keep it this simple:
+
+1. confirm which GCP project actually owns the credits
+2. keep auth on a dedicated local service-account JSON path
+3. route Gemini through `google-vertex/...`, not `google/...`
+4. run one tiny request and then check that billing lands under `Vertex AI`
+
 ## Why this skill exists
 
 Many users can access Google Cloud credits, but still miss the practical setup
@@ -52,7 +62,7 @@ Use this skill when you want a safer first pass for Vertex AI setup:
 4. run one tiny verification request
 5. check Google Cloud Billing before wider rollout
 
-## Why it exists
+## Common mistakes this skill helps prevent
 
 This skill is meant to reduce a few common setup mistakes:
 

--- a/skills/openclaw-vertex-credit-safe-setup/SKILL.md
+++ b/skills/openclaw-vertex-credit-safe-setup/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: openclaw-vertex-credit-safe-setup
-description: Safely configure Google Vertex AI for a fresh OpenClaw setup using a Google Cloud project, service-account JSON auth, minimal-cost verification, and explicit billing checks to avoid accidental Gemini API or extra spend.
+description: Use Google Cloud credits with OpenClaw more safely by routing Gemini through Vertex AI, verifying one tiny request, and checking billing before accidental Gemini API spend shows up.
 version: 1.0.0
 ---
 
 # OpenClaw Vertex Credit-Safe Setup
 
-Use this skill when a user wants to configure Google Vertex AI for OpenClaw from scratch and wants to minimize billing mistakes.
+Use this skill when a user wants to turn Google Cloud credits into a correct OpenClaw -> Vertex AI -> Gemini setup and wants to minimize billing mistakes.
 
 ## Goal
 

--- a/skills/openclaw-vertex-credit-safe-setup/agents/openai.yaml
+++ b/skills/openclaw-vertex-credit-safe-setup/agents/openai.yaml
@@ -1,4 +1,4 @@
 spec_version: "1"
 display_name: "Vertex Credit-Safe Setup"
-short_description: "Safely configure OpenClaw Vertex AI with minimal-cost verification"
-default_prompt: "Use $openclaw-vertex-credit-safe-setup to configure Google Vertex AI for a fresh OpenClaw setup, prefer service-account JSON auth, keep models on google-vertex routes, use the minimal public-safe starter template when the user wants a reference config, run one tiny verification request, and explain how to verify billing and credits."
+short_description: "Use Google Cloud credits with OpenClaw by routing Gemini through Vertex AI safely"
+default_prompt: "Use $openclaw-vertex-credit-safe-setup to turn Google Cloud credits into a correct OpenClaw Vertex AI setup, prefer service-account JSON auth, keep models on google-vertex routes, use the minimal public-safe starter template when the user wants a reference config, run one tiny verification request, and explain how to verify billing and credits before wider rollout."


### PR DESCRIPTION
## Summary
- sharpen the Vertex skill README and root README entry points for Google Cloud credits users
- improve the skill metadata copy used for GitHub and future ClawHub presentation
- record the copy-only changes in the repo and skill changelogs

## Verification
- ./validate_repo.sh