### PR TITLE
Sync Vertex skill 1.0.1 ClawHub patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows a lightweight keep-a-changelog style.
 
 ## [Unreleased]
 
+- Published `openclaw-vertex-credit-safe-setup@1.0.1` to ClawHub with sharper
+  Google credits, Gemini routing, and billing-path entry copy
 - Sharpened the Vertex skill entry points and registry-facing metadata so the
   Google credits, Gemini routing, and billing-path story is easier to follow
 - Published `openclaw-vertex-credit-safe-setup@1.0.0` to ClawHub and synced the

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Current focus areas include:
 | `daily-task-checkin` | Lightweight task intake, reminders, completion confirmation, and follow-up coordination | `1.0.2` | [`skills/daily-task-checkin/`](./skills/daily-task-checkin/) |
 | `practice-session-checkin` | Structured practice intake, start confirmation, reminder flow, and follow-up tracking | `1.0.1` | [`skills/practice-session-checkin/`](./skills/practice-session-checkin/) |
 | `mac-multi-instance-deployment` | Generic Mac workspace setup, boundary docs, quickstart examples, and deployment validation | `1.0.4` | [`skills/mac-multi-instance-deployment/`](./skills/mac-multi-instance-deployment/) |
-| `openclaw-vertex-credit-safe-setup` | Use Google Cloud credits with Gemini through Vertex AI, tiny verification, and billing checks | `1.0.0` | [`skills/openclaw-vertex-credit-safe-setup/`](./skills/openclaw-vertex-credit-safe-setup/) |
+| `openclaw-vertex-credit-safe-setup` | Use Google Cloud credits with Gemini through Vertex AI, tiny verification, and billing checks | `1.0.1` | [`skills/openclaw-vertex-credit-safe-setup/`](./skills/openclaw-vertex-credit-safe-setup/) |
 
 ### Featured Entry Point
 

--- a/skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md
+++ b/skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.1
 
 - Sharpened the GitHub and ClawHub-facing copy around Google credits, Gemini
   routing, and billing-path verification

--- a/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
+++ b/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
@@ -34,7 +34,7 @@ Use this skill when you want a reusable public template for:
 
 - GitHub: yes
 - Feishu knowledge-base: yes, as a repository-facing summary update
-- ClawHub: published as `openclaw-vertex-credit-safe-setup@1.0.0`
+- ClawHub: published as `openclaw-vertex-credit-safe-setup@1.0.1`
 
 This skill now has the minimum packaging needed for a stable public registry
 entry and has been published on ClawHub.

--- a/skills/openclaw-vertex-credit-safe-setup/README.md
+++ b/skills/openclaw-vertex-credit-safe-setup/README.md
@@ -4,7 +4,7 @@ Public-safe OpenClaw skill for connecting a fresh local setup to Google Vertex
 AI with service-account JSON auth, one tiny verification request, and explicit
 billing checks.
 
-Published on ClawHub as `openclaw-vertex-credit-safe-setup@1.0.0`.
+Published on ClawHub as `openclaw-vertex-credit-safe-setup@1.0.1`.
 
 ## Start here if you already have credits
 
@@ -118,6 +118,7 @@ skills/
       vertex-first-setup-checklist.md
     releases/
       1.0.0.md
+      1.0.1.md
 ```
 
 ## Safety boundaries
@@ -162,4 +163,5 @@ request succeeds.
 
 - [examples/README.md](./examples/README.md)
 - [CUSTOMIZATION.md](./CUSTOMIZATION.md)
+- [releases/1.0.1.md](./releases/1.0.1.md)
 - [releases/1.0.0.md](./releases/1.0.0.md)

--- a/skills/openclaw-vertex-credit-safe-setup/SKILL.md
+++ b/skills/openclaw-vertex-credit-safe-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openclaw-vertex-credit-safe-setup
 description: Use Google Cloud credits with OpenClaw more safely by routing Gemini through Vertex AI, verifying one tiny request, and checking billing before accidental Gemini API spend shows up.
-version: 1.0.0
+version: 1.0.1
 ---
 
 # OpenClaw Vertex Credit-Safe Setup

--- a/skills/openclaw-vertex-credit-safe-setup/releases/1.0.1.md
+++ b/skills/openclaw-vertex-credit-safe-setup/releases/1.0.1.md
@@ -1,0 +1,21 @@
+# v1.0.1
+
+## Highlights
+
+- made the Google Cloud credits use case more obvious in the skill summary
+- clarified that the main risk is accidental Gemini API spend when routing is wrong
+- improved the shortest "start here" path for users who already have credits
+
+## Changes
+
+- `skills/openclaw-vertex-credit-safe-setup/SKILL.md`
+- `skills/openclaw-vertex-credit-safe-setup/README.md`
+- `skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md`
+- `skills/openclaw-vertex-credit-safe-setup/agents/openai.yaml`
+- `skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md`
+- `README.md`
+
+## Notes
+
+- This is a copy-and-metadata patch release. The skill logic and safety boundary stay the same.
+- Keep all project IDs, JSON credential files, and billing details local-only.


### PR DESCRIPTION
## Summary
- sync the repo to the published `openclaw-vertex-credit-safe-setup@1.0.1` ClawHub patch
- update the skill version, release note, and published version references
- record the ClawHub patch in the repo changelog

## Verification
- ./validate_repo.sh
- npx --yes clawhub inspect openclaw-vertex-credit-safe-setup