### PR TITLE
Fix Vertex skill ClawHub bundle source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows a lightweight keep-a-changelog style.
 
 ## [Unreleased]
 
+- Published `openclaw-vertex-credit-safe-setup@1.0.2` to ClawHub after verifying
+  the full repo skill bundle, not the stale workspace copy, was the published source
 - Published `openclaw-vertex-credit-safe-setup@1.0.1` to ClawHub with sharper
   Google credits, Gemini routing, and billing-path entry copy
 - Sharpened the Vertex skill entry points and registry-facing metadata so the

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Current focus areas include:
 | `daily-task-checkin` | Lightweight task intake, reminders, completion confirmation, and follow-up coordination | `1.0.2` | [`skills/daily-task-checkin/`](./skills/daily-task-checkin/) |
 | `practice-session-checkin` | Structured practice intake, start confirmation, reminder flow, and follow-up tracking | `1.0.1` | [`skills/practice-session-checkin/`](./skills/practice-session-checkin/) |
 | `mac-multi-instance-deployment` | Generic Mac workspace setup, boundary docs, quickstart examples, and deployment validation | `1.0.4` | [`skills/mac-multi-instance-deployment/`](./skills/mac-multi-instance-deployment/) |
-| `openclaw-vertex-credit-safe-setup` | Use Google Cloud credits with Gemini through Vertex AI, tiny verification, and billing checks | `1.0.1` | [`skills/openclaw-vertex-credit-safe-setup/`](./skills/openclaw-vertex-credit-safe-setup/) |
+| `openclaw-vertex-credit-safe-setup` | Use Google Cloud credits with Gemini through Vertex AI, tiny verification, and billing checks | `1.0.2` | [`skills/openclaw-vertex-credit-safe-setup/`](./skills/openclaw-vertex-credit-safe-setup/) |
 
 ### Featured Entry Point
 

--- a/skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md
+++ b/skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2
+
+- republished the complete repo skill bundle after verifying that the previous
+  ClawHub patch had captured a stale workspace copy instead of the full repo version
+- kept the Google credits, Gemini routing, and billing-path entry copy improvements
+
 ## 1.0.1
 
 - Sharpened the GitHub and ClawHub-facing copy around Google credits, Gemini

--- a/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
+++ b/skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md
@@ -34,7 +34,7 @@ Use this skill when you want a reusable public template for:
 
 - GitHub: yes
 - Feishu knowledge-base: yes, as a repository-facing summary update
-- ClawHub: published as `openclaw-vertex-credit-safe-setup@1.0.1`
+- ClawHub: published as `openclaw-vertex-credit-safe-setup@1.0.2`
 
 This skill now has the minimum packaging needed for a stable public registry
 entry and has been published on ClawHub.

--- a/skills/openclaw-vertex-credit-safe-setup/README.md
+++ b/skills/openclaw-vertex-credit-safe-setup/README.md
@@ -4,7 +4,7 @@ Public-safe OpenClaw skill for connecting a fresh local setup to Google Vertex
 AI with service-account JSON auth, one tiny verification request, and explicit
 billing checks.
 
-Published on ClawHub as `openclaw-vertex-credit-safe-setup@1.0.1`.
+Published on ClawHub as `openclaw-vertex-credit-safe-setup@1.0.2`.
 
 ## Start here if you already have credits
 
@@ -119,6 +119,7 @@ skills/
     releases/
       1.0.0.md
       1.0.1.md
+      1.0.2.md
 ```
 
 ## Safety boundaries
@@ -163,5 +164,6 @@ request succeeds.
 
 - [examples/README.md](./examples/README.md)
 - [CUSTOMIZATION.md](./CUSTOMIZATION.md)
+- [releases/1.0.2.md](./releases/1.0.2.md)
 - [releases/1.0.1.md](./releases/1.0.1.md)
 - [releases/1.0.0.md](./releases/1.0.0.md)

--- a/skills/openclaw-vertex-credit-safe-setup/SKILL.md
+++ b/skills/openclaw-vertex-credit-safe-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openclaw-vertex-credit-safe-setup
 description: Use Google Cloud credits with OpenClaw more safely by routing Gemini through Vertex AI, verifying one tiny request, and checking billing before accidental Gemini API spend shows up.
-version: 1.0.1
+version: 1.0.2
 ---
 
 # OpenClaw Vertex Credit-Safe Setup

--- a/skills/openclaw-vertex-credit-safe-setup/releases/1.0.2.md
+++ b/skills/openclaw-vertex-credit-safe-setup/releases/1.0.2.md
@@ -1,0 +1,21 @@
+# v1.0.2
+
+## Highlights
+
+- republished the complete repo version of the skill after verifying that the previous patch had used a stale workspace copy
+- kept the Google Cloud credits, Gemini routing, and billing-path entry copy improvements
+- rechecked the ClawHub install path so the published bundle now matches the full repo structure
+
+## Changes
+
+- `skills/openclaw-vertex-credit-safe-setup/SKILL.md`
+- `skills/openclaw-vertex-credit-safe-setup/README.md`
+- `skills/openclaw-vertex-credit-safe-setup/CHANGELOG.md`
+- `skills/openclaw-vertex-credit-safe-setup/PUBLISHING.md`
+- `skills/openclaw-vertex-credit-safe-setup/releases/1.0.2.md`
+- `README.md`
+
+## Notes
+
+- `1.0.2` is the verified full-bundle ClawHub fix release.
+- Keep all project IDs, JSON credential files, and billing details local-only.


### PR DESCRIPTION
## Summary
- sync the repo to the verified openclaw-vertex-credit-safe-setup@1.0.2 ClawHub release
- document that 1.0.2 fixes a stale workspace-source publish issue from the previous patch
- update the published version references and add the new skill release note

## Verification
- ./validate_repo.sh
- npx --yes clawhub inspect openclaw-vertex-credit-safe-setup --version 1.0.2 --files
- npx --yes clawhub inspect openclaw-vertex-credit-safe-setup --version 1.0.2 --file SKILL.md
- npx --yes clawhub inspect openclaw-vertex-credit-safe-setup --version 1.0.2 --file README.md