### PR TITLE
Prepare v0.1.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,25 @@ The format follows a lightweight keep-a-changelog style.
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-04-01
+
 - Published `openclaw-vertex-credit-safe-setup@1.0.2` to ClawHub after verifying
   the full repo skill bundle, not the stale workspace copy, was the published source
-- Published `openclaw-vertex-credit-safe-setup@1.0.1` to ClawHub with sharper
-  Google credits, Gemini routing, and billing-path entry copy
-- Sharpened the Vertex skill entry points and registry-facing metadata so the
-  Google credits, Gemini routing, and billing-path story is easier to follow
 - Published `openclaw-vertex-credit-safe-setup@1.0.0` to ClawHub and synced the
   public repo status
 - Expanded the Vertex setup skill with examples, customization guidance, and a
   first skill release note for ClawHub evaluation
+- Sharpened the Vertex skill entry points and registry-facing metadata so the
+  Google credits, Gemini routing, and billing-path story is easier to follow
+- Added repository-side Xiaohongshu launch assets for the Vertex skill story
+
+## [0.1.8] - 2026-03-31
+
 - Added a GitHub-first public-safe skill for credit-safe Google Vertex AI setup
 - Added repository and knowledge-base references for the new Vertex setup skill
+
+## [0.1.7] - 2026-03-30
+
 - Quota-aware switching now uses public-safe config variables for threshold,
   target model, and agent list defaults
 - README and Feishu knowledge-base docs now foreground the public-safe

--- a/generate_public_pack.sh
+++ b/generate_public_pack.sh
@@ -83,6 +83,7 @@ files=(
   "releases/0.1.6.md"
   "releases/0.1.7.md"
   "releases/0.1.8.md"
+  "releases/0.1.9.md"
 )
 
 if [[ "$mode" == "--list" ]]; then

--- a/releases/0.1.9.md
+++ b/releases/0.1.9.md
@@ -1,0 +1,32 @@
+# v0.1.9
+
+## Highlights
+
+- Published `openclaw-vertex-credit-safe-setup` to ClawHub and verified the
+  final `1.0.2` package against the full repo bundle
+- Expanded the Vertex setup skill with examples, customization guidance, and a
+  clearer Google credits plus billing-path entry flow
+- Added repository-side launch assets for the Vertex skill story and normalized
+  the Xiaohongshu asset layout
+
+## Changes
+
+- `skills/openclaw-vertex-credit-safe-setup/`
+- `README.md`
+- `CHANGELOG.md`
+- `validate_repo.sh`
+- `generate_public_pack.sh`
+- `marketing/feishu/knowledge-base/01-project-overview.md`
+- `marketing/feishu/knowledge-base/02-publishing-copy.md`
+- `marketing/feishu/knowledge-base/07-project-milestones.md`
+- `marketing/xiaohongshu/README.md`
+- `marketing/xiaohongshu/2026-04-01-vertex-credit-note-pack.md`
+- `assets/xiaohongshu/`
+
+## Notes
+
+- This release moves the Vertex setup line from GitHub-first scaffolding to a
+  verified ClawHub-published skill.
+- A stale workspace-sourced patch was corrected in `openclaw-vertex-credit-safe-setup@1.0.2`.
+- The skill now has a verified minimal live Vertex request path, but billing
+  line-item confirmation still belongs in the Google Cloud console.

--- a/validate_repo.sh
+++ b/validate_repo.sh
@@ -19,6 +19,7 @@ required=(
   "releases/0.1.6.md"
   "releases/0.1.7.md"
   "releases/0.1.8.md"
+  "releases/0.1.9.md"
   "skills/family-homework-pomodoro/SKILL.md"
   "skills/family-homework-pomodoro/README.md"
   "skills/family-homework-pomodoro/agents/openai.yaml"
@@ -28,6 +29,8 @@ required=(
   "skills/openclaw-vertex-credit-safe-setup/agents/openai.yaml"
   "skills/openclaw-vertex-credit-safe-setup/examples/README.md"
   "skills/openclaw-vertex-credit-safe-setup/releases/1.0.0.md"
+  "skills/openclaw-vertex-credit-safe-setup/releases/1.0.1.md"
+  "skills/openclaw-vertex-credit-safe-setup/releases/1.0.2.md"
 )
 
 missing=0


### PR DESCRIPTION
## Summary
- add the v0.1.9 release note and split recent history into 0.1.7, 0.1.8, and 0.1.9 changelog sections
- extend repo validation to cover releases/0.1.9.md and the newer Vertex skill release notes
- include releases/0.1.9.md in the public pack manifest

## Verification
- ./validate_repo.sh
- ./generate_public_pack.sh --dry-run