### PR TITLE
Sync public GitHub identity to guoma970

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ few local checks.
 ## Steps
 
 ```bash
-git clone https://github.com/ztl970/openclaw-oss-starter.git
+git clone https://github.com/guoma970/openclaw-oss-starter.git
 cd openclaw-oss-starter
 chmod +x cron/codex_quota_autoswitch.sh generate_public_pack.sh validate_repo.sh
 ./validate_repo.sh

--- a/config/main-project-registry.example.yaml
+++ b/config/main-project-registry.example.yaml
@@ -4,7 +4,7 @@ projects:
   - key: openclaw-oss-starter
     title: OpenClaw OSS Starter
     local_path: /Users/ztl/Documents/New project
-    github_repo: ztl970/openclaw-oss-starter
+    github_repo: guoma970/openclaw-oss-starter
     sensitivity: public
     public_sync:
       github: true

--- a/marketing/feishu/knowledge-base/01-project-overview.md
+++ b/marketing/feishu/knowledge-base/01-project-overview.md
@@ -44,4 +44,4 @@
 ## 项目地址
 
 GitHub:
-https://github.com/ztl970/openclaw-oss-starter
+https://github.com/guoma970/openclaw-oss-starter

--- a/marketing/feishu/knowledge-base/02-publishing-copy.md
+++ b/marketing/feishu/knowledge-base/02-publishing-copy.md
@@ -12,7 +12,7 @@ have Google Cloud credits, but still need a clear way to configure OpenClaw so
 Gemini usage lands on the Vertex AI billing path instead of a wrong setup path.
 
 GitHub:
-https://github.com/ztl970/openclaw-oss-starter
+https://github.com/guoma970/openclaw-oss-starter
 
 ## Feishu 首发标准版
 
@@ -36,7 +36,7 @@ The direction is simple:
 - help users turn available Google Cloud credits into a correct OpenClaw setup path
 
 GitHub:
-https://github.com/ztl970/openclaw-oss-starter
+https://github.com/guoma970/openclaw-oss-starter
 
 ## 海报/卡片短文案
 

--- a/marketing/feishu/knowledge-base/10-link-index.md
+++ b/marketing/feishu/knowledge-base/10-link-index.md
@@ -3,7 +3,7 @@
 ## 项目主链接
 
 - GitHub 仓库：
-  https://github.com/ztl970/openclaw-oss-starter
+  https://github.com/guoma970/openclaw-oss-starter
 
 ## 当前知识库目录
 

--- a/marketing/feishu/knowledge-base/12-command-library.md
+++ b/marketing/feishu/knowledge-base/12-command-library.md
@@ -15,7 +15,7 @@
 - GitHub 项目相关工作，统一先从 `main` 入口对接
 - 默认项目上下文：
   - 本地仓库：`/Users/ztl/Documents/New project`
-  - GitHub 仓库：`ztl970/openclaw-oss-starter`
+  - GitHub 仓库：`guoma970/openclaw-oss-starter`
 - `main` 负责判断、分流、回报
 - `media` 负责公开同步执行
 - 飞书里的 `小果` 是 `media` 这个实例对应的机器人名字

--- a/marketing/feishu/knowledge-base/17-blocker-and-exception-rules.md
+++ b/marketing/feishu/knowledge-base/17-blocker-and-exception-rules.md
@@ -15,7 +15,7 @@
 当用户没有明确指定其他项目时，默认使用：
 
 - 本地仓库：`/Users/ztl/Documents/New project`
-- GitHub 仓库：`ztl970/openclaw-oss-starter`
+- GitHub 仓库：`guoma970/openclaw-oss-starter`
 - 分支：`main`
 
 只要任务与这个项目明显相关，就不应因为“未给 repo”而直接 blocker。

--- a/marketing/feishu/knowledge-base/37-main-takeover-readiness-checklist.md
+++ b/marketing/feishu/knowledge-base/37-main-takeover-readiness-checklist.md
@@ -22,7 +22,7 @@
 - 默认本地仓库路径已确认：
   - `/Users/ztl/Documents/New project`
 - 默认 GitHub 仓库已确认：
-  - `ztl970/openclaw-oss-starter`
+  - `guoma970/openclaw-oss-starter`
 - 默认分支已确认：
   - `main`
 

--- a/marketing/feishu/knowledge-base/38-official-group-activation-plan.md
+++ b/marketing/feishu/knowledge-base/38-official-group-activation-plan.md
@@ -23,7 +23,7 @@
 本群默认继承当前项目上下文：
 
 - 默认项目：`openclaw-oss-starter`
-- 默认 GitHub 仓库：`ztl970/openclaw-oss-starter`
+- 默认 GitHub 仓库：`guoma970/openclaw-oss-starter`
 - 默认工作区：`/Users/ztl/Documents/New project`
 - 默认协作链：`main -> 小果 -> 果爸`
 

--- a/marketing/feishu/knowledge-base/46-official-group-default-context-rule.md
+++ b/marketing/feishu/knowledge-base/46-official-group-default-context-rule.md
@@ -14,7 +14,7 @@
 
 - 项目：`openclaw-oss-starter`
 - 本地工作区：`/Users/ztl/Documents/New project`
-- GitHub 仓库：`ztl970/openclaw-oss-starter`
+- GitHub 仓库：`guoma970/openclaw-oss-starter`
 - 公开链路：GitHub / ClawHub / 飞书知识库
 
 ## 默认协作对象

--- a/marketing/feishu/knowledge-base/MAIN_CHAT_COMMANDS.md
+++ b/marketing/feishu/knowledge-base/MAIN_CHAT_COMMANDS.md
@@ -12,7 +12,7 @@ chat window.
 Default project context:
 
 - local repository path: `/Users/ztl/Documents/New project`
-- GitHub repository: `ztl970/openclaw-oss-starter`
+- GitHub repository: `guoma970/openclaw-oss-starter`
 - if no other repo is named, `main` should use this one
 
 ## Knowledge-base sync

--- a/marketing/feishu/knowledge-base/MAIN_GITHUB_RESPONSIBILITIES.md
+++ b/marketing/feishu/knowledge-base/MAIN_GITHUB_RESPONSIBILITIES.md
@@ -9,7 +9,7 @@ All GitHub project work should enter through `main` first.
 Default assumption:
 
 - local repository path: `/Users/ztl/Documents/New project`
-- GitHub repository: `ztl970/openclaw-oss-starter`
+- GitHub repository: `guoma970/openclaw-oss-starter`
 
 If the user does not name another repository, `main` should use this project
 context by default instead of blocking for missing repo identity.

--- a/marketing/feishu/knowledge-base/MAIN_NEW_SKILL_FLOW.md
+++ b/marketing/feishu/knowledge-base/MAIN_NEW_SKILL_FLOW.md
@@ -16,7 +16,7 @@ Let `main` control the full lifecycle of a new skill:
 Default repository context:
 
 - local repository path: `/Users/ztl/Documents/New project`
-- GitHub repository: `ztl970/openclaw-oss-starter`
+- GitHub repository: `guoma970/openclaw-oss-starter`
 
 ## Standard flow
 

--- a/marketing/feishu/knowledge-base/MAIN_PROJECT_CONTEXT.md
+++ b/marketing/feishu/knowledge-base/MAIN_PROJECT_CONTEXT.md
@@ -6,12 +6,12 @@ through `main`.
 ## Default project
 
 - local repository path: `/Users/ztl/Documents/New project`
-- GitHub repository: `ztl970/openclaw-oss-starter`
+- GitHub repository: `guoma970/openclaw-oss-starter`
 - default branch: `main`
 
 ## Public sync targets
 
-- GitHub repository: `ztl970/openclaw-oss-starter`
+- GitHub repository: `guoma970/openclaw-oss-starter`
 - ClawHub skills published from this repository
 - Feishu knowledge-base parent:
   `https://www.feishu.cn/wiki/CLJFwc9l8ik7IRkpi8bcPgAMn6U`

--- a/marketing/feishu/knowledge-base/MAIN_ROUTING_RULES.md
+++ b/marketing/feishu/knowledge-base/MAIN_ROUTING_RULES.md
@@ -14,7 +14,7 @@ Codex work.
 Unless the user explicitly names another repository, `main` should assume:
 
 - local repository path: `/Users/ztl/Documents/New project`
-- GitHub repository: `ztl970/openclaw-oss-starter`
+- GitHub repository: `guoma970/openclaw-oss-starter`
 - default branch: `main`
 
 ## Routing classes

--- a/marketing/github/final-profile-setup-checklist.md
+++ b/marketing/github/final-profile-setup-checklist.md
@@ -2,7 +2,7 @@
 
 ## Already done
 
-- profile repository created: `ztl970/ztl970`
+- profile repository created: `guoma970/guoma970`
 - profile README pushed
 - main public repository banner added
 - wide and narrow banner assets generated

--- a/marketing/github/github-maintenance-handover.md
+++ b/marketing/github/github-maintenance-handover.md
@@ -6,7 +6,7 @@
 
 ## 适用仓库
 
-- 仓库名：`ztl970/openclaw-oss-starter`
+- 仓库名：`guoma970/openclaw-oss-starter`
 - 本地路径：`/Users/ztl/Documents/New project`
 - 默认分支：`main`
 
@@ -63,7 +63,7 @@
 ## 当前公开面状态
 
 - GitHub 个人 `Bio` 已统一
-- GitHub profile repo 已建立：`ztl970/ztl970`
+- GitHub profile repo 已建立：`guoma970/guoma970`
 - 主仓库 description 已统一
 - ClawHub `Bio` 已统一
 - 主仓库首页、banner、application pack 已整理

--- a/marketing/github/profile-readme-draft.md
+++ b/marketing/github/profile-readme-draft.md
@@ -1,13 +1,13 @@
 # GitHub Profile README Draft
 
-Use this for the future `ztl970/ztl970` profile repository.
+Use this for the `guoma970/guoma970` profile repository.
 
 ```md
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ztl970/openclaw-oss-starter/main/assets/github/profile-banner-1280.png" alt="OpenClaw profile banner" />
+  <img src="https://raw.githubusercontent.com/guoma970/openclaw-oss-starter/main/assets/github/profile-banner-1280.png" alt="OpenClaw profile banner" />
 </p>
 
-# Hi, I'm ztl970
+# Hi, I'm guoma970
 
 Building public-safe OpenClaw workflow templates across reusable skill publishing and workflow operations.
 
@@ -20,7 +20,7 @@ Building public-safe OpenClaw workflow templates across reusable skill publishin
 
 ## Featured project
 
-### [openclaw-oss-starter](https://github.com/ztl970/openclaw-oss-starter)
+### [openclaw-oss-starter](https://github.com/guoma970/openclaw-oss-starter)
 
 Public-safe OpenClaw skill templates for local AI coordination workflows.
 

--- a/marketing/github/profile-readme-short.md
+++ b/marketing/github/profile-readme-short.md
@@ -1,13 +1,13 @@
 # GitHub Profile README Short Variant
 
 ```md
-# Hi, I'm ztl970
+# Hi, I'm guoma970
 
 Building public-safe OpenClaw workflow templates across reusable skill publishing and workflow operations.
 
 ## Featured repo
 
-- [openclaw-oss-starter](https://github.com/ztl970/openclaw-oss-starter)
+- [openclaw-oss-starter](https://github.com/guoma970/openclaw-oss-starter)
 
 ## Current themes
 


### PR DESCRIPTION
## Summary
- update current GitHub-facing docs and default repo references to guoma970
- align install and project registry entry points with the new owner
- carry the profile README materials onto the same public identity baseline

## Validation
- ./validate_repo.sh